### PR TITLE
PTECH-500: Add Authenticated only support to script.

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -170,11 +170,15 @@ phantomcss.init({
 casper.start();
 casper.setHttpAuth('demo', 'demo').then(function () {
   this.options.waitTimeout = 15000;
-})
-.each(pageNames, testPage) // Processes every page as Anonymous user.
-.then(function() {
+});
+
+if (!config.runAuthenticatedOnly) {
+  casper.each(pageNames, testPage) // Processes every page as Anonymous user.
+}
+
+casper.then(function() {
   // Conditional processing as Authenticated user.
-  if (runAuthenticated) {
+  if (runAuthenticated || config.runAuthenticatedOnly) {
     authenticateUser();
     // Change screenshot prefix.
     screenshotPrefix = config.screenshotPrefixAuth;

--- a/test-config.js
+++ b/test-config.js
@@ -2,7 +2,8 @@ module.exports = {
 	host: require('system').env.HOST, // CasperJS-specific.
 
 	// Variables used for testing as an Authenticated user.
-	runAuthenticated: true, // Set to false if you do wish to run tests as an Authenticated user.
+	runAuthenticated: true, // Set to true if you wish to run tests as an Authenticated user.
+    runAuthenticatedOnly: false, // Set to true if you wish to run tests as Authenticated user ONLY.
 
     loginObj: [
         {


### PR DESCRIPTION
Add support to run test as authenticated user only.

By default, test is executed as:
1. anonymous first, then
2. authenticated.

Added **runAuthenticatedOnly** variable to support some pages that needs to be tested as authenticated only. Otherwise, the default logic applies.

These are the combination of **runAuthenticated** and **runAuthenticatedOnly** variables and how it will affect the test suite:
- runAuthenticated: true, runAuthenticatedOnly: true => run tests as authenticated **only**.
- runAuthenticated: true, runAuthenticatedOnly: false => run tests as anonymous and authenticated.
- runAuthenticated: false, runAuthenticatedOnly: true => run tests as authenticated **only**.
- runAuthenticated: false, runAuthenticatedOnly: false => run tests as anonymous **only**.

Hope this helps.


Thanks!